### PR TITLE
Fix Google Fonts rendering

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -5,7 +5,7 @@ export default function Document() {
     <Html>
       <Head>
         <link
-          href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@200;400;600;800&display=optional"
+          href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@200;400;600;800&display=swap"
           rel="stylesheet"
         />
       </Head>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,6 +4,8 @@ export default function Document() {
   return (
     <Html>
       <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
           href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@200;400;600;800&display=swap"
           rel="stylesheet"


### PR DESCRIPTION
### Overview
The custom font used on the website was not rendering on initial load. 

After investigating the connection links between the website and the Google Fonts server, I've noticed that the `display` parameter in the Google Fonts import URL was set to `optional`, when it should be `swap`.

This fixed the issue, but I also included `preconnect` links (recommended by Google Fonts), so that the connection between the website and Google Fonts server is established faster.

### Related Issue
Fixes #5 

### Tests
- [x] Google Font is rendering on initial load, both in `development` and `production` environments

